### PR TITLE
Swift 3.0 to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   - EXAMPLE_SCHEME="iOS Example"
   matrix:
     - DESTINATION="OS=9.3,name=iPhone 6"          SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="YES"
-    - DESTINATION="OS=10.0,name=iPhone 6S Plus"     SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="YES"
+    - DESTINATION="name=iPhone 7 Plus"     SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="YES"
 script:
   - set -o pipefail
   - xcodebuild -version

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   - EXAMPLE_SCHEME="iOS Example"
   matrix:
     - DESTINATION="OS=9.3,name=iPhone 6S"          SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="YES"
-    - DESTINATION="OS=10,name=iPhone 7 Plus"     SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="YES"
+    - DESTINATION="OS=10.0,name=iPhone 7 Plus"     SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="YES"
 script:
   - set -o pipefail
   - xcodebuild -version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode7.2
+osx_image: xcode8
 language: objective-c
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ env:
   - IOS_SDK=iphonesimulator10.0
   - EXAMPLE_SCHEME="iOS Example"
   matrix:
-    - DESTINATION="OS=9.3,name=iPhone 6S"          SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="YES"
-    - DESTINATION="OS=10.0,name=iPhone 7 Plus"     SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="YES"
+    - DESTINATION="OS=9.3,name=iPhone 6"          SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="YES"
+    - DESTINATION="OS=10.0,name=iPhone 6S Plus"     SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="YES"
 script:
   - set -o pipefail
   - xcodebuild -version

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ env:
   - LANG=en_US.UTF-8
   - PROJECT=BaseView.xcodeproj
   - IOS_FRAMEWORK_SCHEME="BaseView"
-  - IOS_SDK=iphonesimulator9.2
+  - IOS_SDK=iphonesimulator10.0
   - EXAMPLE_SCHEME="iOS Example"
   matrix:
-    - DESTINATION="OS=8.3,name=iPhone 4S"          SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="YES"
-    - DESTINATION="OS=9.2,name=iPhone 6S Plus"     SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="YES"
+    - DESTINATION="OS=9.3,name=iPhone 6S"          SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="YES"
+    - DESTINATION="OS=10,name=iPhone 7 Plus"     SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="YES"
 script:
   - set -o pipefail
   - xcodebuild -version

--- a/BaseView.xcodeproj/project.pbxproj
+++ b/BaseView.xcodeproj/project.pbxproj
@@ -179,14 +179,16 @@
 			attributes = {
 				LastSwiftMigration = 0710;
 				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 0720;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = ustwo;
 				TargetAttributes = {
 					AA5A47C21B2F8F7F000A7D30 = {
 						CreatedOnToolsVersion = 6.3.2;
+						LastSwiftMigration = 0800;
 					};
 					AA5A47D71B2F8F7F000A7D30 = {
 						CreatedOnToolsVersion = 6.3.2;
+						LastSwiftMigration = 0800;
 						TestTargetID = AA5A47C21B2F8F7F000A7D30;
 					};
 				};
@@ -295,8 +297,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -341,8 +345,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -361,6 +367,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -374,6 +381,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ustwo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -385,6 +393,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ustwo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -401,6 +410,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ustwo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BaseView.app/BaseView";
 			};
 			name = Debug;
@@ -414,6 +424,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ustwo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BaseView.app/BaseView";
 			};
 			name = Release;

--- a/BaseView.xcodeproj/xcshareddata/xcschemes/BaseView.xcscheme
+++ b/BaseView.xcodeproj/xcshareddata/xcschemes/BaseView.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/BaseView/AppDelegate.swift
+++ b/BaseView/AppDelegate.swift
@@ -13,7 +13,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }

--- a/BaseView/View.swift
+++ b/BaseView/View.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class View: BaseView {
 
-    private(set) var titleLabel: UILabel!
+    fileprivate(set) var titleLabel: UILabel!
 
     
     // MARK: - Setup
@@ -19,7 +19,7 @@ class View: BaseView {
 
         super.setup()
 
-        self.backgroundColor = UIColor.redColor()
+        self.backgroundColor = UIColor.red
 
         self.titleLabel = UILabel()
         self.titleLabel.text = "Some text"
@@ -35,8 +35,8 @@ class View: BaseView {
 
         self.titleLabel.translatesAutoresizingMaskIntoConstraints = false
 
-        self.addConstraint(NSLayoutConstraint(item: self.titleLabel, attribute: .Left, relatedBy: .Equal, toItem: self.titleLabel.superview, attribute: .Left, multiplier: 1.0, constant: 0.0))
-        self.addConstraint(NSLayoutConstraint(item: self.titleLabel, attribute: .Right, relatedBy: .Equal, toItem: self.titleLabel.superview, attribute: .Right, multiplier: 1.0, constant: 0.0))
-        self.addConstraint(NSLayoutConstraint(item: self.titleLabel, attribute: .Top, relatedBy: .Equal, toItem: self.titleLabel.superview, attribute: .Top, multiplier: 1.0, constant: 0.0))
+        self.addConstraint(NSLayoutConstraint(item: self.titleLabel, attribute: .left, relatedBy: .equal, toItem: self.titleLabel.superview, attribute: .left, multiplier: 1.0, constant: 0.0))
+        self.addConstraint(NSLayoutConstraint(item: self.titleLabel, attribute: .right, relatedBy: .equal, toItem: self.titleLabel.superview, attribute: .right, multiplier: 1.0, constant: 0.0))
+        self.addConstraint(NSLayoutConstraint(item: self.titleLabel, attribute: .top, relatedBy: .equal, toItem: self.titleLabel.superview, attribute: .top, multiplier: 1.0, constant: 0.0))
     }
 }

--- a/BaseViewTests/BaseViewTests.swift
+++ b/BaseViewTests/BaseViewTests.swift
@@ -18,7 +18,7 @@ class BaseViewTests: XCTestCase {
     
     func testAwakeFromNib() {
         // Given
-        let testView = NSBundle.mainBundle().loadNibNamed("BaseView", owner: self, options: nil).last as? BaseView
+        let testView = Bundle.main.loadNibNamed("BaseView", owner: self, options: nil)?.last as? BaseView
         
         // Test
         XCTAssertNotNil(testView)
@@ -30,8 +30,8 @@ class BaseViewTests: XCTestCase {
         let testView = BaseView()
         
         // When
-        let archive = NSKeyedArchiver.archivedDataWithRootObject(testView)
-        let result = NSKeyedUnarchiver.unarchiveObjectWithData(archive) as? BaseView
+        let archive = NSKeyedArchiver.archivedData(withRootObject: testView)
+        let result = NSKeyedUnarchiver.unarchiveObject(with: archive) as? BaseView
         
         // Test
         XCTAssertNotNil(result)
@@ -39,7 +39,7 @@ class BaseViewTests: XCTestCase {
     
     func testInitWithFrame() {
         // Given
-        let testView = BaseView(frame: CGRectZero)
+        let testView = BaseView(frame: CGRect.zero)
 
         // Then
         XCTAssertNotNil(testView)

--- a/BaseViewTests/ViewControllerTests.swift
+++ b/BaseViewTests/ViewControllerTests.swift
@@ -20,7 +20,7 @@ class ViewControllerTests: XCTestCase {
         let viewController = ViewController()
 
         // When
-        UIApplication.sharedApplication().keyWindow!.rootViewController = viewController
+        UIApplication.shared.keyWindow!.rootViewController = viewController
 
         // Test
         XCTAssertNotNil(viewController.view)

--- a/Sources/BaseView.swift
+++ b/Sources/BaseView.swift
@@ -29,9 +29,9 @@ import UIKit
 /**
     BaseView acts as a common base for all custom views
 */
-@objc public class BaseView: UIView {
+@objc open class BaseView: UIView {
 
-    public private(set) var isSetup: Bool = false
+    open fileprivate(set) var isSetup: Bool = false
 
 
     // MARK: - Initialisers
@@ -52,7 +52,7 @@ import UIKit
         super.init(coder: aDecoder)
     }
     
-    override public  func awakeFromNib() {
+    override open  func awakeFromNib() {
     
         super.awakeFromNib()
 
@@ -76,7 +76,7 @@ import UIKit
     
     Override this function to initialize subviews, set default values, etc.
     */
-    public func setup() {
+    open func setup() {
         // Abstract method.
     }
     
@@ -90,7 +90,7 @@ import UIKit
     
     - Note: It is best to use this for static identifiers that will not change at runtime. For dynamically generated identifiers or identifiers that will change over time, we recommend doing this in the view controller or view model as appropriate.
     */
-    public func setupAccessibility() {
+    open func setupAccessibility() {
         // Abstract method.
     }
     
@@ -102,7 +102,7 @@ import UIKit
     
     Override this function to add layout constraints for all the subviews.
     */
-    public func setupConstraints() {
+    open func setupConstraints() {
         // Abstract method.
     }
 }


### PR DESCRIPTION
Fixes #16 Updated to Swift 3.0 syntax using Xcode 8 GM 
# Description
- Using `open` instead of `public` so that the class can be modified outside its own module 
- Enums now use lower case  
- Foundation updates dropping the (NS) prefix where appropriate 
# Status
- [x] Code Review
